### PR TITLE
Update Overseerr Template

### DIFF
--- a/root/app/www/public/templates/radarr/overseerr.json
+++ b/root/app/www/public/templates/radarr/overseerr.json
@@ -19,6 +19,7 @@
         "get"
     ],
     "/api/v3/tag": [
-        "get"
+        "get",
+        "post"
     ]
 }


### PR DESCRIPTION
Adds `POST` to the `/tag/` endpoint to support creating a tag whenever it doesn't exist if a user wishes to tag movies from Overseerr with the user who requested the movie