### PR TITLE
LunaSea Template and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ There are some pre-built templates that enable just the api access the app actua
 - DAPS
 - Jellyseerr
 - Kometa
+- LunaSea
 - Nabarr
 - Notifiarr
 - Omegabrr

--- a/root/app/www/public/templates/radarr/lunasea.json
+++ b/root/app/www/public/templates/radarr/lunasea.json
@@ -1,0 +1,84 @@
+{
+    "/api/v3/calendar": [
+        "get"
+    ],
+    "/api/v3/command": [
+        "post"
+    ],
+    "/api/v3/credit": [
+        "get"
+    ],
+    "/api/v3/diskspace": [
+        "get"
+    ],
+    "/api/v3/extrafile": [
+        "get"
+    ],
+    "/api/v3/filesystem": [
+        "get"
+    ],
+    "/api/v3/history": [
+        "get"
+    ],
+    "/api/v3/history/movie": [
+        "get"
+    ],
+    "/api/v3/exclusions": [
+        "get"
+    ],
+    "/api/v3/importlist/movie": [
+        "get"
+    ],
+    "/api/v3/language": [
+        "get"
+    ],
+    "/api/v3/manualimport": [
+        "get"
+    ],
+    "/api/v3/mediacover/{movieId}/{filename}": [
+        "get"
+    ],
+    "/api/v3/movie": [
+        "get",
+        "post",
+        "put"
+    ],
+    "/api/v3/movie/{id}": [
+        "get"
+    ],
+    "/api/v3/moviefile": [
+        "get"
+    ],
+    "/api/v3/moviefile/{id}": [
+        "delete"
+    ],
+    "/api/v3/qualityprofile": [
+        "get"
+    ],
+    "/api/v3/queue/{id}": [
+        "delete"
+    ],
+    "/api/v3/queue": [
+        "get"
+    ],
+    "/api/v3/release": [
+        "get",
+        "post"
+    ],
+    "/api/v3/rootfolder": [
+        "get"
+    ],
+    "/api/v3/system/status": [
+        "get"
+    ],
+    "/api/v3/tag": [
+        "get",
+        "post"
+    ],
+    "/api/v3/tag/{id}": [
+        "delete"
+    ],
+    "/api/v3/qualitydefinition": [
+        "get"
+    ]
+}

--- a/root/app/www/public/templates/sonarr/lunasea.json
+++ b/root/app/www/public/templates/sonarr/lunasea.json
@@ -1,0 +1,76 @@
+{
+    "/api/v3/calendar": [
+        "get"
+    ],
+    "/api/v3/command": [
+        "post"
+    ],
+    "/api/v3/episode": [
+        "get"
+    ],
+    "/api/v3/episode/monitor": [
+        "put"
+    ],
+    "/api/v3/episodefile": [
+        "get"
+    ],
+    "/api/v3/episodefile/{id}": [
+        "delete"
+    ],
+    "/api/v3/history": [
+        "get"
+    ],
+    "/api/v3/history/series": [
+        "get"
+    ],
+    "/api/v3/importlistexclusion": [
+        "get"
+    ],
+    "/api/v3/languageprofile": [
+        "get"
+    ],
+    "/api/v3/mediacover/{seriesId}/{filename}": [
+        "get"
+    ],
+    "/api/v3/wanted/missing": [
+        "get"
+    ],
+    "/api/v3/qualityprofile": [
+        "get"
+    ],
+    "/api/v3/queue/{id}": [
+        "delete"
+    ],
+    "/api/v3/queue": [
+        "get"
+    ],
+    "/api/v3/queue/details": [
+        "get"
+    ],
+    "/api/v3/release": [
+        "get",
+        "post"
+    ],
+    "/api/v3/rootfolder": [
+        "get"
+    ],
+    "/api/v3/series": [
+        "get",
+        "post",
+        "put"
+    ],
+    "/api/v3/series/{id}": [
+        "delete",
+        "get"
+    ],
+    "/api/v3/system/status": [
+        "get"
+    ],
+    "/api/v3/tag": [
+        "get",
+        "post"
+    ],
+    "/api/v3/tag/{id}": [
+        "delete"
+    ]
+}


### PR DESCRIPTION
This is the setup for LunaSea template I found when I tested and all the functions it uses, while for radarr the qualitydefinitions endpoint didn't seem actually necessary as it didn't block any functionality I came across it will still constantly call it so I decided to allow so that it doesn't needlessly spam block notifications or inflates the usage counter with rejections that don't have any meaning in regards to monitoring gone rogue apps but can be removed if you think it should

If I do come across any endpoints that I somehow missed I'll update but I tested everything I could see and click on so far