### PR TITLE
Update titlecardmaker.json

### DIFF
--- a/root/app/www/public/templates/sonarr/titlecardmaker.json
+++ b/root/app/www/public/templates/sonarr/titlecardmaker.json
@@ -8,9 +8,6 @@
     "/api/v3/tag": [
         "get"
     ],
-    "/api/v3/episode/": [
-        "get"
-    ],
     "/api/v3/series/lookup": [
         "get"
     ],


### PR DESCRIPTION
fixed titlecardmaker to remove the "duplicate" endpoint, the one with the trailing slash