### PR TITLE
feat(template): DAPS added missing API endpoints

### DIFF
--- a/root/app/www/public/templates/radarr/daps.json
+++ b/root/app/www/public/templates/radarr/daps.json
@@ -23,5 +23,8 @@
     ],
     "/api/v3/qualityprofile": [
         "get"
+    ],
+    "/api/v3/health": [
+        "get"
     ]
 }

--- a/root/app/www/public/templates/sonarr/daps.json
+++ b/root/app/www/public/templates/sonarr/daps.json
@@ -7,5 +7,11 @@
     ],
     "/api/v3/episode": [
         "get"
+    ],
+    "/api/v3/health": [
+        "get"
+    ],
+    "/api/v3/qualityprofile": [
+        "get"
     ]
 }


### PR DESCRIPTION
Added: missing  DAPS API endpoint for Radarr/Sonarr

Radarr:
```json
    "/api/v3/health": [
        "get"
    ]
```

Sonarr:

```json
    "/api/v3/health": [
        "get"
    ],
    "/api/v3/qualityprofile": [
        "get"
    ]
```

**DISCLAIMER:** _I've tested this update for several days and approved all logged API endpoints. However, it's still possible that some API endpoints aren't logged on my side because of different usage._