### PR TITLE
feat(template): autobrr added missing API endpoints

### DIFF
--- a/root/app/www/public/templates/radarr/autobrr.json
+++ b/root/app/www/public/templates/radarr/autobrr.json
@@ -1,8 +1,14 @@
 {
+    "/api/v3/movie": [
+        "get"
+    ],
     "/api/v3/release/push": [
         "post"
     ],
     "/api/v3/system/status": [
+        "get"
+    ],
+    "/api/v3/tag": [
         "get"
     ]
 }

--- a/root/app/www/public/templates/sonarr/autobrr.json
+++ b/root/app/www/public/templates/sonarr/autobrr.json
@@ -4,5 +4,11 @@
     ],
     "/api/v3/system/status": [
         "get"
+    ],
+    "/api/v3/tag": [
+        "get"
+    ],
+    "/api/v3/series": [
+        "get"
     ]
 }


### PR DESCRIPTION
Added: missing  autobrr API endpoint for Radarr/Sonarr, mainly because of the integration of Omegabrr

Radarr:
```json
    "/api/v3/movie": [
        "get"
    ],
    "/api/v3/release/push": [
        "post"
    ],
    "/api/v3/system/status": [
        "get"
    ],
    "/api/v3/tag": [
        "get"
    ]
```

Sonarr:

```json
    "/api/v3/system/status": [
        "get"
    ],
    "/api/v3/tag": [
        "get"
    ],
    "/api/v3/series": [
        "get"
    ]
```

**DISCLAIMER:** _I've tested this update for several days and approved all logged API endpoints. However, it's still possible that some API endpoints aren't logged on my side because of different usage._