### PR TITLE
chore(github): add issue form templates with issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug Report
+description: File a bug report to help us improve Starr Proxy
+title: "Bug - "
+labels: ["bug", "triage"]
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Bug Report
+        Thanks for taking the time to fill out this bug report!
+        Please fill out the information below as detailed as possible.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description of the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: Tell us what should have happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: input
+    id: starrproxy-version
+    attributes:
+      label: Starr Proxy Version
+      description: What version of Starr Proxy are you running?
+      placeholder: "v0.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      description: How are you running Starr Proxy?
+      options:
+        - Docker
+        - Linux (native)
+        - Windows
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste any relevant Starr Proxy log output. This will be automatically formatted, so no need for backticks.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here (config snippets, screenshots, etc.).
+      placeholder: Any additional information...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Notifiarr Discord (#starrproxy)
+    url: https://notifiarr.com/discord
+    about: For support and questions, join the Notifiarr Discord and ask in the #starrproxy channel.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature Request
+description: Suggest an idea or enhancement for Starr Proxy
+title: "FR - "
+labels: ["enhancement", "triage"]
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Feature Request
+        Thanks for taking the time to suggest a new feature!
+        Please fill out the information below as detailed as possible.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Description
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see implemented.
+      placeholder: It would be great if...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered.
+      placeholder: I've thought about...
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context, screenshots, or examples about the feature request.
+      placeholder: Any additional information...


### PR DESCRIPTION
Adds GitHub issue form templates to Starr Proxy (there were none).

- **bug_report.yml** — `type: Bug`; fields for description, expected behavior, repro steps, version, deployment, logs.
- **feature_request.yml** — `type: Feature`.
- **config.yml** — disables blank issues; routes support to the Notifiarr Discord `#starrproxy` channel.

Both forms set the org-level issue type via the new top-level `type:` key.