### PR TITLE
feat: add prowlarr templates for qui and cross-seed

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,7 +46,7 @@ jobs:
             # https://github.com/docker/login-action
             - name: Log into registry ${{ env.REGISTRY }}
               if: github.event_name != 'pull_request'
-              uses: docker/login-action@v3
+              uses: docker/login-action@v4
               with:
                   registry: ${{ env.REGISTRY }}
                   username: ${{ github.actor }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
-FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.23@sha256:1dfb1e075fdc7e4ddf0a2b70f1c6efa2c4f96054b22ecf02c30e9112d8b7fbea
+FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.23@sha256:e26dae7e0c918cced5ba13efcebbf5db027e6064a0f84b10f2e73916827d023d
 ARG TARGETARCH
 
 # Version labels

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
-FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.23@sha256:e26dae7e0c918cced5ba13efcebbf5db027e6064a0f84b10f2e73916827d023d
+FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.23@sha256:8f12eba041f7d5ba9bd4850737e8f7053f8c6649917b7064600eb623d3f241c0
 ARG TARGETARCH
 
 # Version labels

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
+# syntax=docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
 FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.23@sha256:df4f74363956c6b5de55d3445e5759858d9d1fd798231d60f88cec756ee143f2
 ARG TARGETARCH
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
-FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.23@sha256:8f12eba041f7d5ba9bd4850737e8f7053f8c6649917b7064600eb623d3f241c0
+FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.23@sha256:f784ea7172c18ef5276b40c6fb5ab831a402cb1ae38ee34d3462a80111fdb2db
 ARG TARGETARCH
 
 # Version labels

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+# syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
 FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.23@sha256:1dfb1e075fdc7e4ddf0a2b70f1c6efa2c4f96054b22ecf02c30e9112d8b7fbea
 ARG TARGETARCH
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
-FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.23@sha256:df4f74363956c6b5de55d3445e5759858d9d1fd798231d60f88cec756ee143f2
+FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.23@sha256:1dfb1e075fdc7e4ddf0a2b70f1c6efa2c4f96054b22ecf02c30e9112d8b7fbea
 ARG TARGETARCH
 
 # Version labels

--- a/root/app/www/public/js/starr.js
+++ b/root/app/www/public/js/starr.js
@@ -169,6 +169,13 @@ function deleteAppStarrAccess(app, id)
     }
 }
 // -------------------------------------------------------------------------------------------
+function resetUsageCounts(app, id)
+{
+    $('#' + app + '-' + id + '-requestCount').html('0');
+    $('#' + app + '-' + id + '-allowedCount').html('0');
+    $('#' + app + '-' + id + '-blockedCount').html('0');
+}
+// -------------------------------------------------------------------------------------------
 function resetUsage(app, id)
 {
     if (confirm('Are you sure you want to reset the usage counter?')) {
@@ -182,7 +189,7 @@ function resetUsage(app, id)
                     return;
                 }
 
-                reload();
+                resetUsageCounts(app, id);
             }
         });
     }

--- a/root/app/www/public/pages/starr.php
+++ b/root/app/www/public/pages/starr.php
@@ -81,7 +81,7 @@ if (!$_SESSION['IN_UI']) {
                                     </td>
                                     <td><input type="text" class="form-control" id="instance-username-<?= $starrInstance['id'] ?>" placeholder="username" value="<?= $starrInstance['username'] ?>"></td>
                                     <td><input type="password" class="form-control" id="instance-password-<?= $starrInstance['id'] ?>" placeholder="password" value="<?= $starrInstance['password'] ?>"></td>
-                                    <td align="right">
+                                    <td class="text-end">
                                         <button class="btn btn-outline-info" type="button" onclick="testStarr('<?= $starrInstance['id'] ?>', '<?= $app ?>')"><i class="fas fa-network-wired"></i></button>
                                         <button class="btn btn-outline-success" type="button" onclick="saveStarr('<?= $starrInstance['id'] ?>', '<?= $app ?>')"><i class="fas fa-save"></i></button>
                                         <button class="btn btn-outline-danger" type="button" onclick="deleteStarr('<?= $starrInstance['id'] ?>', '<?= $app ?>')"><i class="fas fa-trash-alt"></i></button>
@@ -97,7 +97,7 @@ if (!$_SESSION['IN_UI']) {
                             <td><input type="text" class="form-control" id="instance-apikey-99" placeholder="12345-67890-09876-54321"></td>
                             <td><input type="text" class="form-control" id="instance-username-99" placeholder="username"></td>
                             <td><input type="text" class="form-control" id="instance-password-99" placeholder="password"></td>
-                            <td align="right">
+                            <td class="text-end">
                                 <button class="btn btn-outline-info" type="button" onclick="testStarr('99', '<?= $app ?>')"><i class="fas fa-network-wired"></i></button>
                                 <button class="btn btn-outline-success" type="button" onclick="saveStarr('99', '<?= $app ?>')"><i class="fas fa-plus-circle"></i></button>
                             </td>
@@ -166,8 +166,8 @@ if (!$_SESSION['IN_UI']) {
                                         <span id="app-<?= $accessApp['id'] ?>-apikey" style="display: none;"><?= $accessApp['apikey'] ?></span>
                                     </td>
                                     <td>
-                                        <?= number_format($usage['allowed'] + $usage['rejected']) ?> request<?= $usage['allowed'] + $usage['rejected'] == 1 ? '' : 's' ?><br>
-                                        <span class="text-small">Allowed: <?= number_format($usage['allowed']) ?> Blocked: <?= number_format($usage['rejected']) ?></span>
+                                        <span id="<?= $app ?>-<?= $accessApp['id'] ?>-requestCount"><?= number_format($usage['allowed'] + $usage['rejected']) ?></span> request<?= $usage['allowed'] + $usage['rejected'] == 1 ? '' : 's' ?><br>
+                                        <span class="text-small">Allowed: <span id="<?= $app ?>-<?= $accessApp['id'] ?>-allowedCount"><?= number_format($usage['allowed']) ?></span> Blocked: <span id="<?= $app ?>-<?= $accessApp['id'] ?>-blockedCount"><?= number_format($usage['rejected']) ?></span></span>
                                     </td>
                                     <td class="text-center">
                                         <div class="dropdown">

--- a/root/app/www/public/templates/prowlarr/cross-seed.json
+++ b/root/app/www/public/templates/prowlarr/cross-seed.json
@@ -1,0 +1,11 @@
+{
+    "/api/v1/search": [
+        "get"
+    ],
+    "/api/v1/indexer": [
+        "get"
+    ],
+    "/api/v1/indexer/{id}/newznab": [
+        "get"
+    ]
+}

--- a/root/app/www/public/templates/prowlarr/qui.json
+++ b/root/app/www/public/templates/prowlarr/qui.json
@@ -1,0 +1,11 @@
+{
+    "/api/v1/search": [
+        "get"
+    ],
+    "/api/v1/indexer": [
+        "get"
+    ],
+    "/api/v1/indexer/{id}/newznab": [
+        "get"
+    ]
+}


### PR DESCRIPTION
## Summary

Add Torznab-scoped templates for qui and cross-seed applications to the prowlarr endpoint set.

Both applications use minimal read-only endpoints:
- `/api/v1/search` (GET) — search indexers
- `/api/v1/indexer` (GET) — list available indexers
- `/api/v1/indexer/{id}/newznab` (GET) — newznab feed endpoint

This allows qui and cross-seed to search prowlarr indexers via scoped API keys without exposing full indexer management or configuration access.

## Tested

- Templates registered in starrproxy
- Scoped keys issued to both qui and cross-seed
- Verified endpoint access via key validation