### PR TITLE
feat(templates): add native Ruddarr template (radarr + sonarr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ There are some pre-built templates that enable just the api access the app actua
 - Prowlarr
 - Qui\*
 - Recyclarr\*
+- Ruddarr
 - Seerr\*
 - TitleCardMaker
 - Unmanic

--- a/root/app/www/public/templates/radarr/ruddarr.json
+++ b/root/app/www/public/templates/radarr/ruddarr.json
@@ -1,0 +1,73 @@
+{
+    "/api/v3/calendar": [
+        "get"
+    ],
+    "/api/v3/command": [
+        "post"
+    ],
+    "/api/v3/diskspace": [
+        "get"
+    ],
+    "/api/v3/extrafile": [
+        "get"
+    ],
+    "/api/v3/history": [
+        "get"
+    ],
+    "/api/v3/history/movie": [
+        "get"
+    ],
+    "/api/v3/manualimport": [
+        "get"
+    ],
+    "/api/v3/movie": [
+        "get",
+        "post"
+    ],
+    "/api/v3/movie/{id}": [
+        "get",
+        "delete"
+    ],
+    "/api/v3/movie/editor": [
+        "put"
+    ],
+    "/api/v3/movie/lookup": [
+        "get"
+    ],
+    "/api/v3/moviefile": [
+        "get"
+    ],
+    "/api/v3/moviefile/{id}": [
+        "delete"
+    ],
+    "/api/v3/notification": [
+        "get",
+        "post"
+    ],
+    "/api/v3/notification/{id}": [
+        "put",
+        "delete"
+    ],
+    "/api/v3/qualityprofile": [
+        "get"
+    ],
+    "/api/v3/queue": [
+        "get"
+    ],
+    "/api/v3/queue/{id}": [
+        "delete"
+    ],
+    "/api/v3/release": [
+        "get",
+        "post"
+    ],
+    "/api/v3/rootfolder": [
+        "get"
+    ],
+    "/api/v3/system/status": [
+        "get"
+    ],
+    "/api/v3/tag": [
+        "get"
+    ]
+}

--- a/root/app/www/public/templates/sonarr/ruddarr.json
+++ b/root/app/www/public/templates/sonarr/ruddarr.json
@@ -1,0 +1,77 @@
+{
+    "/api/v3/calendar": [
+        "get"
+    ],
+    "/api/v3/command": [
+        "post"
+    ],
+    "/api/v3/diskspace": [
+        "get"
+    ],
+    "/api/v3/episode": [
+        "get"
+    ],
+    "/api/v3/episode/monitor": [
+        "put"
+    ],
+    "/api/v3/episodefile": [
+        "get"
+    ],
+    "/api/v3/episodefile/{id}": [
+        "delete"
+    ],
+    "/api/v3/episodefile/bulk": [
+        "delete"
+    ],
+    "/api/v3/history": [
+        "get"
+    ],
+    "/api/v3/manualimport": [
+        "get"
+    ],
+    "/api/v3/notification": [
+        "get",
+        "post"
+    ],
+    "/api/v3/notification/{id}": [
+        "put",
+        "delete"
+    ],
+    "/api/v3/qualityprofile": [
+        "get"
+    ],
+    "/api/v3/queue": [
+        "get"
+    ],
+    "/api/v3/queue/{id}": [
+        "delete"
+    ],
+    "/api/v3/release": [
+        "get",
+        "post"
+    ],
+    "/api/v3/rootfolder": [
+        "get"
+    ],
+    "/api/v3/series": [
+        "get",
+        "post"
+    ],
+    "/api/v3/series/{id}": [
+        "get",
+        "put",
+        "delete"
+    ],
+    "/api/v3/series/editor": [
+        "put"
+    ],
+    "/api/v3/series/lookup": [
+        "get"
+    ],
+    "/api/v3/system/status": [
+        "get"
+    ],
+    "/api/v3/tag": [
+        "get"
+    ]
+}


### PR DESCRIPTION
Ruddarr (native iOS companion app for Radarr/Sonarr) currently has no template and is typically registered against `lunasea.json` as a workaround, which grants more than Ruddarr actually uses.

Scope derived from ground truth, not cloned from lunasea: read `ruddarr/app`'s `API+Live.swift` (the single file issuing every network call) to determine actual endpoint usage.

Notable differences from lunasea/nzb360's scope:
- Ruddarr fetches poster art via each release's own `remoteURL`, not the arr's `/api/v3/mediacover` proxy - so mediacover is deliberately not granted.
- Push-notification webhook sync needs `/api/v3/notification` CRUD.
- Sonarr side needs `/api/v3/episodefile/bulk` (delete), not granted by any existing sonarr template.
- Confirmed the proxy lowercases incoming paths before matching (`api/index.php`), so Ruddarr's one mixed-case path (`episodeFile` GET vs `episodefile` DELETE) is normalized to lowercase-only here.