### PR TITLE
fix(templates): radarr/nabarr grants sonarr's importlistexclusion route, not radarr's

### DIFF
--- a/root/app/www/public/templates/radarr/nabarr.json
+++ b/root/app/www/public/templates/radarr/nabarr.json
@@ -8,13 +8,6 @@
         "delete",
         "get"
     ],
-    "/api/v3/importlistexclusion": [
-        "get",
-        "post"
-    ],
-    "/api/v3/importlistexclusion/{id}": [
-        "put"
-    ],
     "/api/v3/movie": [
         "get",
         "post"


### PR DESCRIPTION
\`radarr/nabarr.json\` granted \`/api/v3/importlistexclusion\` (+ \`/{id}\`), which doesn't exist on Radarr - that's Sonarr's route name. Radarr's own \`ImportListExclusionController\` overrides its route to \`exclusions\`, which this same template file already correctly grants separately.

Verified via both repos' \`ImportListExclusionController.cs\` route attributes, and nabarr's own client source (\`l3uddz/nabarr\`) confirming its Radarr client only ever calls GET \`/exclusions\`, its Sonarr client only GET \`/importlistexclusion\`.