### PR TITLE
fix(templates): lidarr/organizr uses v3 endpoints that don't exist on Lidarr (v1-only API)

### DIFF
--- a/root/app/www/public/templates/lidarr/organizr.json
+++ b/root/app/www/public/templates/lidarr/organizr.json
@@ -1,11 +1,11 @@
 {
-    "/api/v3/rootfolder": [
+    "/api/v1/rootfolder": [
         "get"
     ],
-    "/api/v3/calendar": [
+    "/api/v1/calendar": [
         "get"
     ],
-    "/api/v3/queue": [
+    "/api/v1/queue": [
         "get"
     ]
 }


### PR DESCRIPTION
\`lidarr/organizr.json\` used \`/api/v3/*\` (rootfolder, calendar, queue), which don't exist on Lidarr - its API is exclusively v1 (confirmed via the \`Lidarr.Api.V1\` namespace on \`RootFolderController\`/\`CalendarController\`/\`QueueController\`).

Content was byte-identical to \`radarr/organizr.json\` otherwise - a copy-paste that never updated the version prefix. Every request Organizr currently sends against Lidarr through this template 404s.