### PR TITLE
fix(templates): radarr/prowlarr grants a POST Prowlarr never sends

### DIFF
--- a/root/app/www/public/templates/radarr/prowlarr.json
+++ b/root/app/www/public/templates/radarr/prowlarr.json
@@ -5,8 +5,7 @@
     ],
     "/api/v3/indexer/{id}": [
         "put",
-        "get",
-        "post"
+        "get"
     ],
     "/api/v3/indexer/schema": [
         "get"


### PR DESCRIPTION
\`radarr/prowlarr.json\` granted POST on \`/api/v3/indexer/{id}\`; \`sonarr/prowlarr.json\` (same consumer) doesn't. Verified via Prowlarr's own \`RadarrV3Proxy.cs\`: it POSTs only to the bare \`/indexer\` collection endpoint, and PUTs (never POSTs) to \`/indexer/{id}\`.

Removed the unused grant so radarr's template matches sonarr's scope and Prowlarr's actual request pattern.