### PR TITLE
fix(templates): fill Kometa gaps for Radarr and Sonarr

### DIFF
--- a/root/app/www/public/templates/radarr/kometa.json
+++ b/root/app/www/public/templates/radarr/kometa.json
@@ -8,6 +8,13 @@
     "/api/v3/movie/lookup": [
         "get"
     ],
+    "/api/v3/movie/import": [
+        "post"
+    ],
+    "/api/v3/movie/editor": [
+        "put",
+        "delete"
+    ],
     "/api/v3/qualityprofile": [
         "get"
     ],
@@ -21,12 +28,7 @@
         "get"
     ],
     "/api/v3/tag": [
-        "get"
-    ],
-    "/api/v3/movie/import": [
+        "get",
         "post"
-    ],
-    "/api/v3/movie/editor": [
-        "put"
     ]
 }

--- a/root/app/www/public/templates/sonarr/kometa.json
+++ b/root/app/www/public/templates/sonarr/kometa.json
@@ -2,11 +2,30 @@
     "/api/v3/importlistexclusion": [
         "get"
     ],
+    "/api/v3/languageprofile": [
+        "get"
+    ],
     "/api/v3/rootfolder": [
         "get"
     ],
     "/api/v3/rootfolder/{id}": [
         "get"
+    ],
+    "/api/v3/seasonpass": [
+        "post"
+    ],
+    "/api/v3/series": [
+        "get"
+    ],
+    "/api/v3/series/import": [
+        "post"
+    ],
+    "/api/v3/series/lookup": [
+        "get"
+    ],
+    "/api/v3/series/editor": [
+        "put",
+        "delete"
     ],
     "/api/v3/system/status": [
         "get"
@@ -14,17 +33,8 @@
     "/api/v3/qualityprofile": [
         "get"
     ],
-    "/api/v3/series": [
+    "/api/v3/tag": [
         "get",
         "post"
-    ],
-    "/api/v3/series/lookup": [
-        "get"
-    ],
-    "/api/v3/series/editor": [
-        "put"
-    ],
-    "/api/v3/tag": [
-        "get"
     ]
 }


### PR DESCRIPTION
## Summary

Completes the Kometa template coverage by researching [Kometa-Team/ArrAPI](https://github.com/Kometa-Team/ArrAPI) (the library Kometa uses for Radarr/Sonarr integration). Builds on the recent sonarr/kometa series-endpoint fix — this adds the remaining endpoints required for normal Kometa operation.

## Changes

### radarr/kometa
- Add `DELETE` on `/api/v3/movie/editor` — bulk delete via `delete_multiple_movies()` (`remove_all_with_tags`, collection cleanup)
- Add `POST` on `/api/v3/tag` — auto-create tags when configured labels don't exist (`_validate_tags`)

### sonarr/kometa
- Add `POST /api/v3/series/import` — bulk add path used by `add_multiple_series()` (replaces ineffective `POST /series`)
- Add `DELETE` on `/api/v3/series/editor` — bulk delete via `delete_multiple_series()`
- Add `GET /api/v3/languageprofile` — required on init for Sonarr v3 `_validate_add_options()`
- Add `POST /api/v3/seasonpass` — monitor changes when `monitor_existing` is enabled
- Add `POST` on `/api/v3/tag` — tag auto-creation
- Remove `POST` on `/api/v3/series` — Kometa's add flow uses `/series/import`, not the collection route

## Test plan

- [ ] Apply updated `kometa` template to Radarr and Sonarr proxy apps
- [ ] Run Kometa with `add_missing`, tag assignment, and `monitor_existing` enabled
- [ ] Confirm Starr Proxy access log shows no rejected requests for the endpoints above