### PR TITLE
fix(templates): align radarr/sonarr prowlarr with Prowlarr sync client

### DIFF
--- a/root/app/www/public/templates/radarr/prowlarr.json
+++ b/root/app/www/public/templates/radarr/prowlarr.json
@@ -4,29 +4,14 @@
         "post"
     ],
     "/api/v3/indexer/{id}": [
+        "get",
         "put",
-        "get"
+        "delete"
     ],
     "/api/v3/indexer/schema": [
         "get"
     ],
     "/api/v3/indexer/test": [
         "post"
-    ],
-    "/api/v3/indexer/testall": [
-        "post"
-    ],
-    "/api/v3/indexer/action/{name}": [
-        "post"
-    ],
-    "/api/v3/config/indexer": [
-        "get"
-    ],
-    "/api/v3/config/indexer/{id}": [
-        "put",
-        "get"
-    ],
-    "/api/v3/indexerflag": [
-        "get"
     ]
 }

--- a/root/app/www/public/templates/sonarr/prowlarr.json
+++ b/root/app/www/public/templates/sonarr/prowlarr.json
@@ -4,29 +4,14 @@
         "post"
     ],
     "/api/v3/indexer/{id}": [
+        "get",
         "put",
-        "get"
+        "delete"
     ],
     "/api/v3/indexer/schema": [
         "get"
     ],
     "/api/v3/indexer/test": [
         "post"
-    ],
-    "/api/v3/indexer/testall": [
-        "post"
-    ],
-    "/api/v3/config/indexer": [
-        "get"
-    ],
-    "/api/v3/config/indexer/{id}": [
-        "put",
-        "get"
-    ],
-    "/api/v3/indexerflag": [
-        "get"
-    ],
-    "/api/v3/system/status": [
-        "get"
     ]
 }


### PR DESCRIPTION
Verified against Prowlarr RadarrV3Proxy.cs and SonarrV3Proxy.cs:
- Add DELETE on /api/v3/indexer/{id} (RemoveIndexer)
- Remove endpoints Prowlarr never calls: indexer/testall, indexer/action/{name}, config/indexer*, indexerflag, system/status