### PR TITLE
docs: document :main vs :develop image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ Errors:
 
 ## Installation
 
+### Image tags
+
+- `:main` — release channel, updated when a build is cut from `main`.
+- `:develop` — tracks the `develop` branch directly, rebuilt on every merge to `develop`. May be ahead of `:main` between releases; use it if you need a fix that's merged but not yet released on `:main`.
+
+Both tags carry standard `org.opencontainers.image.*` labels (`.created`, `.revision`) — check those on a pulled image if you need to know exactly what's in it.
+
 ### Compose example
 
 ``` yaml


### PR DESCRIPTION
## Summary

README's install examples pin `:main`, but there's no mention of `:develop` or what the difference is. Adds a short "Image tags" section under Installation explaining both, plus a pointer to the `org.opencontainers.image.*` labels already on both tags for anyone who wants to check exactly what's in a pulled image.

Context: `:main` is the release channel and only rebuilds when a build is cut from `main`; `:develop` rebuilds on every merge to `develop`, so it can be ahead of `:main` between releases — worth knowing if you're chasing a fix that's merged but not yet released.

No functional/template changes, docs only.