### PR TITLE
fix(timeout): Increase curl timeout to 60s instead of 10s

### DIFF
--- a/root/app/www/public/functions/curl.php
+++ b/root/app/www/public/functions/curl.php
@@ -7,7 +7,7 @@
 ----------------------------------
 */
 
-function curl($url, $headers = [], $method = 'GET', $payload = '', $userPass = [], $timeout = 10)
+function curl($url, $headers = [], $method = 'GET', $payload = '', $userPass = [], $timeout = 60)
 {
     $payload = !is_string($payload) ? '' : $payload;
 


### PR DESCRIPTION
**Issue Experienced:**
Random 502s to upstream applications due to 10s timeout

**Fix:**
Increased timeout in curl from 30s to 60s to allow more time for responses on monolithic arr instances.

**Risks:**
None afaik other than possibility of 60s process hangs while pulling data like movie or series from arr api on a slow host.